### PR TITLE
Do not use DIRECTORY_SEPARATOR for URLs!

### DIFF
--- a/src/Service/Context.php
+++ b/src/Service/Context.php
@@ -115,7 +115,6 @@ class Context extends BasicContext
     public function getShopUrl(): string
     {
         $facts = new Facts();
-        return rtrim($facts->getShopUrl(), DIRECTORY_SEPARATOR) .
-            DIRECTORY_SEPARATOR;
+        return rtrim($facts->getShopUrl(), '/') . '/';
     }
 }


### PR DESCRIPTION
DIRECTORY_SEPARATOR is different on each platforms while URLs always use / (Caution! I didn't check if the code makes sense at all. I only translated it to URLs 1:1)